### PR TITLE
With temp libpaths action

### DIFF
--- a/R/libpaths.R
+++ b/R/libpaths.R
@@ -12,10 +12,9 @@ set_libpaths <- function(paths, action = "replace") {
   invisible(old)
 }
 
-set_temp_libpath <- function() {
-  paths <- tempfile("temp_libpath")
+set_temp_libpath <- function(paths = tempfile("temp_libpath"), action = "prefix") {
   dir.create(paths)
-  set_libpaths(paths, action = "prefix")
+  set_libpaths(paths, action = action)
 }
 
 #' Library paths
@@ -36,6 +35,9 @@ with_libpaths <- with_(set_libpaths, .libPaths)
 #' Temporarily prepend a new temporary directory to the library paths.
 #'
 #' @template with
+#' @param new \code{[character]}\cr New library paths
+#' @param action \code{[character(1)]}\cr should new values \code{"replace"}, \code{"prefix"} or
+#'   \code{"suffix"} existing paths.
 #' @seealso \code{\link{.libPaths}}
 #' @family libpaths
 #' @export

--- a/R/with_.R
+++ b/R/with_.R
@@ -50,6 +50,11 @@ with_ <- function(set, reset = set, envir = parent.frame()) {
     called_fmls[[1]] <- as.symbol("new")
 
     fun_args <- c(alist(new =, code =), fmls[-1L])
+
+    # argument default should be the same if it exists
+    if (!is.null(fmls[[1]])) {
+      fun_args[[1]] <- fmls[[1]]
+    }
   } else {
     # no formals -- only have code
     called_fmls <- NULL

--- a/man/with_temp_libpaths.Rd
+++ b/man/with_temp_libpaths.Rd
@@ -4,10 +4,15 @@
 \alias{with_temp_libpaths}
 \title{Library paths}
 \usage{
-with_temp_libpaths(code)
+with_temp_libpaths(new = tempfile("temp_libpath"), code, action = "prefix")
 }
 \arguments{
+\item{new}{\code{[character]}\cr New library paths}
+
 \item{code}{\code{[any]}\cr Code to execute in the temporary environment}
+
+\item{action}{\code{[character(1)]}\cr should new values \code{"replace"}, \code{"prefix"} or
+\code{"suffix"} existing paths.}
 }
 \value{
 \code{[any]}\cr The results of the evaluation of the \code{code}

--- a/tests/testthat/test-with.R
+++ b/tests/testthat/test-with.R
@@ -56,7 +56,7 @@ test_that("with_libpaths works and resets library", {
 test_that("with_temp_libpaths works and resets library", {
   lib <- .libPaths()
   with_temp_libpaths(
-    expect_equal(.libPaths()[-1], lib)
+    code = expect_equal(.libPaths()[-1], lib)
   )
   expect_equal(lib, .libPaths())
 })


### PR DESCRIPTION
This PR does two things
- Adds a `rename` argument to `with_()`, which if `FALSE` will not try to rename the first argument to `new`. This is useful if the set function does not take a value to set (such as set_temp_libpaths())`.
- Adds a `action` argument to `set_temp_libpaths()` so you can control if you want to prefix, suffix or replace `.libPaths()`.

@krlmlr PTAL when you can, particularly would like feedback on the `rename` API.
