### PR TITLE
Test R 3.1 and 3.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: r
 sudo: false
 cache: packages
 r:
+  - 3.1
+  - 3.2
   - oldrel
   - release
   - devel

--- a/R/devices.R
+++ b/R/devices.R
@@ -3,10 +3,6 @@ NULL
 
 # Internal *_dev functions ------------------------------------------------
 
-cairo_pdf_dev <- wrap(grDevices::cairo_pdf, NULL, grDevices::dev.cur())
-
-cairo_ps_dev <- wrap(grDevices::cairo_ps, NULL, grDevices::dev.cur())
-
 pdf_dev <- wrap(grDevices::pdf, NULL, grDevices::dev.cur())
 
 postscript_dev <- wrap(grDevices::postscript, NULL, grDevices::dev.cur())
@@ -15,6 +11,18 @@ svg_dev <- wrap(grDevices::svg, NULL, grDevices::dev.cur())
 
 xfig_dev <- wrap(grDevices::xfig, NULL, grDevices::dev.cur())
 
+
+# These functions arguments differ between R versions, so just use ...
+
+cairo_pdf_dev <- function(filename, ...) {
+  grDevices::cairo_pdf(filename = filename, ...)
+  grDevices::dev.cur()
+}
+
+cairo_ps_dev <- function(filename, ...) {
+  grDevices::cairo_ps(filename = filename, ...)
+  grDevices::dev.cur()
+}
 
 # These functions arguments differ between unix and windows, so just use ...
 
@@ -56,7 +64,7 @@ jpeg_dev <- function(filename, ...) {
 #' with_pdf(file.path(tempdir(), "test.pdf"), width = 7, height = 5,
 #'   plot(runif(5))
 #' )
-#' 
+#'
 #' # dimensions are in pixels
 #' with_png(file.path(tempdir(), "test.png"), width = 800, height = 600,
 #'   plot(runif(5))

--- a/R/seed.R
+++ b/R/seed.R
@@ -47,5 +47,8 @@ get_valid_seed <- function() {
 }
 
 get_seed <- function() {
-  get0(".Random.seed", globalenv(), mode = "integer")
+  if (!exists(".Random.seed", globalenv(), mode = "integer", inherits = FALSE)) {
+    return(NULL)
+  }
+  get(".Random.seed", globalenv(), mode = "integer", inherits = FALSE)
 }

--- a/man/devices.Rd
+++ b/man/devices.Rd
@@ -30,25 +30,13 @@ with_bmp(new, code, ...)
 
 local_bmp(new, ..., .local_envir = parent.frame())
 
-with_cairo_pdf(new, code, width = 7, height = 7, pointsize = 12,
-  onefile = FALSE, family = "sans", bg = "white",
-  antialias = c("default", "none", "gray", "subpixel"),
-  fallback_resolution = 300)
+with_cairo_pdf(new, code, ...)
 
-local_cairo_pdf(new, width = 7, height = 7, pointsize = 12,
-  onefile = FALSE, family = "sans", bg = "white",
-  antialias = c("default", "none", "gray", "subpixel"),
-  fallback_resolution = 300, .local_envir = parent.frame())
+local_cairo_pdf(new, ..., .local_envir = parent.frame())
 
-with_cairo_ps(new, code, width = 7, height = 7, pointsize = 12,
-  onefile = FALSE, family = "sans", bg = "white",
-  antialias = c("default", "none", "gray", "subpixel"),
-  fallback_resolution = 300)
+with_cairo_ps(new, code, ...)
 
-local_cairo_ps(new, width = 7, height = 7, pointsize = 12,
-  onefile = FALSE, family = "sans", bg = "white",
-  antialias = c("default", "none", "gray", "subpixel"),
-  fallback_resolution = 300, .local_envir = parent.frame())
+local_cairo_ps(new, ..., .local_envir = parent.frame())
 
 with_pdf(new, code, width, height, onefile, family, title, fonts, version,
   paper, encoding, bg, fg, pointsize, pagecentre, colormodel, useDingbats,
@@ -110,8 +98,6 @@ local_jpeg(new, ..., .local_envir = parent.frame())
 
 \item{height}{the height of the device in inches.}
 
-\item{pointsize}{the default pointsize of plotted text (in big points).}
-
 \item{onefile}{should all plots appear in one file or in separate files?}
 
 \item{family}{one of the device-independent font families,
@@ -120,16 +106,6 @@ local_jpeg(new, ..., .local_envir = parent.frame())
     system-dependent way.
     See, the \sQuote{Cairo fonts} section in the help for \code{\link{X11}}.
   }
-
-\item{bg}{the initial background colour: can be overridden by setting
-    par("bg").}
-
-\item{antialias}{string, the type of anti-aliasing (if any) to be used;
-    defaults to \code{"default"}.}
-
-\item{fallback_resolution}{numeric: the resolution in dpi used when
-    falling back to bitmap output.  Prior to \R 3.3.0 this depended on
-    the cairo implementation but was commonly 300.}
 
 \item{title}{title string to embed as the \samp{/Title} field in the
     file.  Defaults to \code{"R Graphics Output"}.}
@@ -158,8 +134,13 @@ local_jpeg(new, ..., .local_envir = parent.frame())
 \item{encoding}{the name of an encoding file.  See
     \code{\link{postscript}} for details.  Defaults to \code{"default"}.}
 
+\item{bg}{the initial background colour: can be overridden by setting
+    par("bg").}
+
 \item{fg}{the initial foreground color to be used.  Defaults to
    \code{"black"}.}
+
+\item{pointsize}{the default pointsize of plotted text (in big points).}
 
 \item{pagecentre}{logical: should the device region be centred on the
     page? -- is only relevant for \code{paper != "special"}.
@@ -200,6 +181,9 @@ local_jpeg(new, ..., .local_envir = parent.frame())
 to \code{"default"}, the value of option \code{"printcmd"}. The
 length limit is \code{2*PATH_MAX}, typically 8096 bytes on unix systems and
 520 bytes on windows.}
+
+\item{antialias}{string, the type of anti-aliasing (if any) to be used;
+    defaults to \code{"default"}.}
 
 \item{defaultfont}{logical: should the device use xfig's default
     font?}

--- a/tests/testthat/test-devices.R
+++ b/tests/testthat/test-devices.R
@@ -26,7 +26,7 @@ test_that("with_*device* functions create a plot file", {
       expect_silent(fns[[i]](filename, print(p)))
     }
     expect_true(file.exists(filename), info = info)
-    expect_gt(file.size(filename), 0, label = info)
+    expect_gt(file.info(filename)$size, 0, label = info)
   }
 
   unlink(plot_dir)
@@ -61,7 +61,7 @@ test_that("local_device functions create a plot file", {
       print(p)
     })(i)
     expect_true(file.exists(filename), info = info)
-    expect_gt(file.size(filename), 0, label = info)
+    expect_gt(file.info(filename)$size, 0, label = info)
   }
 
   unlink(plot_dir)

--- a/tests/testthat/test-namespace.R
+++ b/tests/testthat/test-namespace.R
@@ -41,8 +41,8 @@ test_that("with_namespace works", {
 
     expect_true("<environment: namespace:tools>" %in% search())
 
-    # .BioC_version_associated_with_R_version is a non-exported object in tools
-    expect_true(is.function(.BioC_version_associated_with_R_version))
+    # .check_packages is a non-exported object in tools
+    expect_true(is.function(.check_packages))
   })
 
   # tools namespace still not attached to the search path
@@ -59,8 +59,8 @@ test_that("local_namespace works", {
 
     expect_true("<environment: namespace:tools>" %in% search())
 
-    # .BioC_version_associated_with_R_version is a non-exported object in tools
-    expect_true(is.function(.BioC_version_associated_with_R_version))
+    # .check_packages is a non-exported object in tools
+    expect_true(is.function(.check_packages))
   }
 
   f()


### PR DESCRIPTION
Needs to:

- [x] eliminate `get0()`
- [x] implement a stable interface for the device wrappers
- [ ] fix tests for R 3.1 compatibility

Closes #60.