### PR TITLE
avoid `do.call()` when resetting options

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# withr 2.1.2.9000
+
+- `with_options()` no longer uses `do.call()`, so optiosn are not evaluated on 
+  exit (#73, @mtmorgan).
+
 # withr 2.1.2
 
 - `set_makevars()` is now exported (#68, @gaborcsardi).

--- a/R/options.R
+++ b/R/options.R
@@ -6,6 +6,10 @@ set_options <- function(new_options) {
   do.call(options, as.list(new_options))
 }
 
+reset_options <- function(old_options) {
+    options(old_options)
+}
+
 #' Options
 #'
 #' Temporarily change global options.
@@ -15,8 +19,8 @@ set_options <- function(new_options) {
 #' @inheritParams with_collate
 #' @seealso [options()]
 #' @export
-with_options <- with_(set_options)
+with_options <- with_(set_options, reset_options)
 
 #' @rdname with_options
 #' @export
-local_options <- local_(set_options)
+local_options <- local_(set_options, reset_options)

--- a/man/with_package.Rd
+++ b/man/with_package.Rd
@@ -37,7 +37,7 @@ local_environment(env, pos = 2L, name = format(env),
 \item{help}{the name of a package, given as a \link{name} or
     literal character string, or a character string, depending on
     whether \code{character.only} is \code{FALSE} (default) or
-    \code{TRUE}).}
+    \code{TRUE}.}
 
 \item{pos}{the position on the search list at which to attach the
     loaded namespace.  Can also be the name of a position on the current

--- a/tests/testthat/test-local.R
+++ b/tests/testthat/test-local.R
@@ -51,6 +51,18 @@ test_that("local_options works", {
   expect_false(identical(getOption("zyxxyzyx"), "qwrbbl"))
 })
 
+test_that("local_options(error = ) works", {
+    f <- function(...) 1
+    oopt <- options("error")
+    on.exit(options(oopt))
+    options(error = f)
+    local({
+        local_options(list(error = function(...) 2))
+        expect_identical(2, eval(getOption("error")))
+    })
+    expect_identical(1, eval(getOption("error")))
+})
+
 test_that("local_libpaths works and resets library", {
   lib <- .libPaths()
   new_lib <- "."


### PR DESCRIPTION
- do.call evaluates arguments, so in particular error = ... fails
- fixes r-lib/withr#73