### PR TITLE
adding example of using local_options()

### DIFF
--- a/R/options.R
+++ b/R/options.R
@@ -31,6 +31,20 @@ reset_options <- function(old_options) {
 #'
 #' # modify temporarily multiple options
 #' with_options(list(OutDec = ",", digits = 3), print(pi))
+#'
+#' # modify, within the scope of the function, the number of
+#' # significant digits to print
+#' print_3_digits <- function(x) {
+#'   # assign 3 to the option "digits" for the rest of this function
+#'   # after the function exits, the option will return to its previous
+#'   # value
+#'   local_options(list(digits = 3))
+#'   print(x)
+#' }
+#'
+#' print_3_digits(pi)  # returns 3.14
+#' print(pi)           # returns 3.141593
+
 #' @export
 with_options <- with_(set_options, reset_options)
 

--- a/man/with_options.Rd
+++ b/man/with_options.Rd
@@ -36,6 +36,19 @@ with_options(list(OutDec = ","), print(pi))
 
 # modify temporarily multiple options
 with_options(list(OutDec = ",", digits = 3), print(pi))
+
+# modify, within the scope of the function, the number of
+# significant digits to print
+print_3_digits <- function(x) {
+  # assign 3 to the option "digits" for the rest of this function
+  # after the function exits, the option will return to its previous
+  # value
+  local_options(list(digits = 3))
+  print(x)
+}
+
+print_3_digits(pi)  # returns 3.14
+print(pi)           # returns 3.141593
 }
 \seealso{
 \code{\link{withr}} for examples


### PR DESCRIPTION
local_options() is used to set an option with the scope of the function.
adding an example showing that while inside the function's scope, the
option is set and once outside of the function's scope, the option
returns to its previous value.