### PR TITLE
Remove `help` argument from `with_package()` and `local_package()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # withr 2.1.2.9000
 
+- Remove `help` argument from `with_package()` and `local_package()` (#94, @wendtke).
+
 - `with_preserve_seed()` now restores `.Random.seed` if it is not set
   originally (#124).
 

--- a/R/namespace.R
+++ b/R/namespace.R
@@ -18,12 +18,12 @@
 #' })
 #' }
 #' @export
-with_package <- function(package, code, help, pos = 2, lib.loc = NULL,
+with_package <- function(package, code, pos = 2, lib.loc = NULL,
   character.only = TRUE, logical.return = FALSE, warn.conflicts = FALSE,
   quietly = TRUE, verbose = getOption("verbose")) {
 
   suppressPackageStartupMessages(
-    (get("library"))(package, help = help, pos = pos, lib.loc = lib.loc,
+    (get("library"))(package, pos = pos, lib.loc = lib.loc,
       character.only = character.only, logical.return = logical.return,
       warn.conflicts = warn.conflicts, quietly = quietly, verbose = verbose))
 
@@ -33,13 +33,13 @@ with_package <- function(package, code, help, pos = 2, lib.loc = NULL,
 
 #' @rdname with_package
 #' @export
-local_package <- function(package, help, pos = 2, lib.loc = NULL,
+local_package <- function(package, pos = 2, lib.loc = NULL,
   character.only = TRUE, logical.return = FALSE, warn.conflicts = FALSE,
   quietly = TRUE, verbose = getOption("verbose"),
   .local_envir = parent.frame()) {
 
   suppressPackageStartupMessages(
-    (get("library"))(package, help = help, pos = pos, lib.loc = lib.loc,
+    (get("library"))(package, pos = pos, lib.loc = lib.loc,
       character.only = character.only, logical.return = logical.return,
       warn.conflicts = warn.conflicts, quietly = quietly, verbose = verbose))
 

--- a/man/with_package.Rd
+++ b/man/with_package.Rd
@@ -12,7 +12,6 @@
 with_package(
   package,
   code,
-  help,
   pos = 2,
   lib.loc = NULL,
   character.only = TRUE,
@@ -24,7 +23,6 @@ with_package(
 
 local_package(
   package,
-  help,
   pos = 2,
   lib.loc = NULL,
   character.only = TRUE,
@@ -59,11 +57,6 @@ local_environment(
 \item{package}{\code{[character(1)]}\cr package name to load.}
 
 \item{code}{\code{[any]}\cr Code to execute in the temporary environment}
-
-\item{help}{the name of a package, given as a \link[base]{name} or
-    literal character string, or a character string, depending on
-    whether \code{character.only} is \code{FALSE} (default) or
-    \code{TRUE}.}
 
 \item{pos}{the position on the search list at which to attach the
     loaded namespace.  Can also be the name of a position on the current


### PR DESCRIPTION
Fixes #94 

Note the pre-existing warning in the master branch within Rd file. This PR introduces no new warnings.