### PR TITLE
with_namespace, local_namespace: Propagate warn.conflicts

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # withr (development version)
 
+* `with_namespace()` and `local_namespace()` now pass `warn.conflicts`
+  to `attach()` (@kyleam, #185).
+
 * `local_rng_version()` and `local_seed()` no longer warn when
   restoring `sample.kind` to `"Rounding"` (#167).
 

--- a/R/namespace.R
+++ b/R/namespace.R
@@ -55,7 +55,7 @@ local_package <- function(package, pos = 2, lib.loc = NULL,
 with_namespace <- function(package, code, warn.conflicts = FALSE) {
   ns <- asNamespace(package)
   name <- format(ns)
-  (get("attach"))(ns, name = name, warn.conflicts = FALSE)
+  (get("attach"))(ns, name = name, warn.conflicts = warn.conflicts)
   on.exit(detach(name, character.only = TRUE))
   force(code)
 }
@@ -65,7 +65,7 @@ with_namespace <- function(package, code, warn.conflicts = FALSE) {
 local_namespace <- function(package, .local_envir = parent.frame(), warn.conflicts = FALSE) {
   ns <- asNamespace(package)
   name <- format(ns)
-  (get("attach"))(ns, name = name, warn.conflicts = FALSE)
+  (get("attach"))(ns, name = name, warn.conflicts = warn.conflicts)
   defer(detach(name, character.only = TRUE), envir = .local_envir)
 }
 


### PR DESCRIPTION
When with_namespace() and local_namespace() gained a warn.conflicts
parameter in 4636e74 (Do not warn about conflicts by default,
2017-11-15), the underlying attach() calls were updated to pass a
hard-coded `warn.conflicts = FALSE`.  This was presumably
unintentional because 1) there's no comment or documentation about why
these functions expose warn.conflicts while ignoring it and 2) all
other functions in namespace.R propagate this argument.

Make with_namespace() and local_namespace() pass along the
warn.conflicts argument.