### PR TITLE
Use `old <- get()` idiom instead of `old <- set()` for robustness to early exits

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -54,6 +54,7 @@ Suggests:
     knitr,
     lattice,
     methods,
+    rlang,
     rmarkdown,
     RSQLite,
     testthat (>= 3.0.0)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,30 @@
 # withr (development version)
 
+* `with_()` and `local_()` gain a `get` argument. Supply a getter
+  function to create `with` and `local` functions that are robust to
+  early exits.
+
+  When supplied, this restoration pattern is used:
+
+  ```
+  old <- get()
+  on.exit(set(old))
+  set(new)
+  action()
+  ```
+
+  Instead of:
+
+  ```
+  old <- set(new)
+  on.exit(set(old))
+  action()
+  ```
+
+  This ensures proper restoration of the old state when an early exit
+  occurs during `set()` (for instance when a deprecation warning is
+  caught, see #191).
+
 * `local_tempfile()` gains a lines argument so, if desired, you can pre-fill
   the temporary file with some data.
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # withr (development version)
 
+* `with_locale()`, `local_locale()`, `with_collate()`, and
+  `local_collate()` are now robust to early exits.
+
 * `with_()` and `local_()` gain a `get` argument. Supply a getter
   function to create `with` and `local` functions that are robust to
   early exits.

--- a/R/collate.R
+++ b/R/collate.R
@@ -2,6 +2,7 @@
 
 # collate --------------------------------------------------------------------
 
+get_collate <- function(locale) get_locale(c(LC_COLLATE = locale))[[1]]
 set_collate <- function(locale) set_locale(c(LC_COLLATE = locale))[[1]]
 
 #' Collation Order
@@ -20,8 +21,8 @@ set_collate <- function(locale) set_locale(c(LC_COLLATE = locale))[[1]]
 #' with_collate("C", sort(x))
 #'
 #' @export
-with_collate <- with_(set_collate)
+with_collate <- with_(set_collate, get = get_collate)
 
 #' @rdname with_collate
 #' @export
-local_collate <- local_(set_collate)
+local_collate <- local_(set_collate, get = get_collate)

--- a/R/locale.R
+++ b/R/locale.R
@@ -1,6 +1,19 @@
 # locale ---------------------------------------------------------------------
 
+get_locale <- function(cats) {
+  as_locale_cats(cats)
+  vapply(names(cats), Sys.getlocale, character(1))
+}
+
 set_locale <- function(cats) {
+  cats <- as_locale_cats(cats)
+  old <- get_locale(cats)
+
+  mapply(Sys.setlocale, names(cats), cats)
+  invisible(old)
+}
+
+as_locale_cats <- function(cats) {
   cats <- as_character(cats)
   stopifnot(is.named(cats))
 
@@ -8,10 +21,7 @@ set_locale <- function(cats) {
     stop("Setting LC_ALL category not implemented.", call. = FALSE)
   }
 
-  old <- vapply(names(cats), Sys.getlocale, character(1))
-
-  mapply(Sys.setlocale, names(cats), cats)
-  invisible(old)
+  cats
 }
 
 #' Locale settings
@@ -51,8 +61,8 @@ set_locale <- function(cats) {
 #' with_locale(c(LC_COLLATE = "C"), sort(x))
 #'
 #' @export
-with_locale <- with_(set_locale)
+with_locale <- with_(set_locale, get = get_locale)
 
 #' @rdname with_locale
 #' @export
-local_locale <- local_(set_locale, dots = TRUE)
+local_locale <- local_(set_locale, get = get_locale, dots = TRUE)

--- a/man/with_.Rd
+++ b/man/with_.Rd
@@ -5,9 +5,17 @@
 \alias{with_}
 \title{Create a new "with" or "local" function}
 \usage{
-local_(set, reset = set, envir = parent.frame(), new = TRUE, dots = FALSE)
+local_(
+  set,
+  reset = set,
+  get = NULL,
+  ...,
+  envir = parent.frame(),
+  new = TRUE,
+  dots = FALSE
+)
 
-with_(set, reset = set, envir = parent.frame(), new = TRUE)
+with_(set, reset = set, get = NULL, ..., envir = parent.frame(), new = TRUE)
 }
 \arguments{
 \item{set}{\verb{[function(...)]}\cr Function used to set the state.
@@ -18,6 +26,16 @@ in the formals of the returned function.}
 The first argument can be named arbitrarily, further arguments with default
 values, or a "dots" argument, are supported but not used: The function will
 be called as \code{reset(old)}.}
+
+\item{get}{\verb{function(...)}\cr Optionally, a getter function. If
+supplied, the \code{on.exit()} restoration is set up \emph{before} calling
+\code{set}. This is more robust in edge cases.
+
+For technical reasons, this getter function must have the same
+interface as \code{set}, which means it is passed the new values as
+well. These can be safely ignored.}
+
+\item{...}{These dots are for future extensions and must be empty.}
 
 \item{envir}{\verb{[environment]}\cr Environment of the returned function.}
 

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -1,3 +1,24 @@
 expect_no_output <- function(...) {
   testthat::expect_output(..., regexp = NA)
 }
+
+expect_safe_and_unsafe_unwinding <- function(state,
+                                             with_unsafe,
+                                             with_safe) {
+  early_exit <- function(expr) {
+    tryCatch(expr, my_cnd = identity)
+  }
+
+  with_unsafe(list("var" = "foo"), NULL)
+  expect_null(state[["var"]])
+
+  with_safe(list("var" = "foo"), NULL)
+  expect_null(state[["var"]])
+
+  early_exit(with_safe(list("var" = "foo"), NULL))
+  expect_null(state[["var"]])
+
+  # Problematic behaviour with unsafe variant
+  early_exit(with_unsafe(list("var" = "foo"), NULL))
+  expect_equal(state[["var"]], "foo")
+}


### PR DESCRIPTION
Part of #191.

- Adds `get` argument to `with_` and `local_`. When supplied, a restoration pattern robust to early exit during `set()` is used.
- Supply `get` when creating locale helpers. Should fix the testthat failures on Windows r-devel platforms.