### PR TITLE
Improve global env and knitr unwind

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # withr (development version)
 
+* Local evaluations in the `globalenv()` (as opposed to top-level
+  ones) are now unwound in the same way as regular environments.
+
 * These `with_` and `local_` functions are now robust to early exits (see next bullet):
 
   - `_locale()`
@@ -38,9 +41,11 @@
 * `local_tempfile()` gains a lines argument so, if desired, you can pre-fill
   the temporary file with some data.
 
-* `defer()` now works as expected when run inside of a `.Rmd`. Note that it will
-  be executed at the very end of the session, after the output has been 
-  collected, so you won't see any printed side-effects (#187).
+* `defer()` all `local_` functions now work when run inside of a
+  `.Rmd`. Note that they are executed at the very end of the session,
+  after the output has been collected, so you won't see any printed
+  side-effects (#187). The same applies with interactive knitting,
+  e.g. in notebooks. They are only executed when R exits.
 
 # withr 2.4.3
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -41,7 +41,7 @@
 * `local_tempfile()` gains a lines argument so, if desired, you can pre-fill
   the temporary file with some data.
 
-* `defer()` all `local_` functions now work when run inside of a
+* `defer()` and all `local_*()` functions now work when run inside of a
   `.Rmd`. Note that they are executed at the very end of the session,
   after the output has been collected, so you won't see any printed
   side-effects (#187). The same applies with interactive knitting,

--- a/R/compat-defer.R
+++ b/R/compat-defer.R
@@ -40,18 +40,11 @@ set_handlers <- function(envir, handlers) {
 }
 
 setup_handlers <- function(envir) {
-  in_knitr <- in_knitr(envir)
-
-  if (in_knitr || is_top_level_global_env(envir)) {
-    # for global environment we use reg.finalizer()
+  if (in_knitr(envir) || is_top_level_global_env(envir)) {
+    # For session scopes we use reg.finalizer()
     if (is_interactive()) {
-      if (in_knitr) {
-        ctxt <- "for the knitr document"
-      } else {
-        ctxt <- "on the global environment"
-      }
       message(
-        sprintf("Setting deferred event(s) %s.\n", ctxt),
+        sprintf("Setting deferred event(s) on the global environment.\n"),
         "  * Will be run automatically when session ends\n",
         "  * Execute (and clear) with `withr::deferred_run()`.\n",
         "  * Clear (without executing) with `withr::deferred_clear()`."

--- a/R/compat-defer.R
+++ b/R/compat-defer.R
@@ -45,7 +45,7 @@ setup_handlers <- function(envir) {
     if (is_interactive()) {
       message(
         sprintf("Setting deferred event(s) on the global environment.\n"),
-        "  * Will be run automatically when session ends\n",
+        "  * Will be run automatically when session ends.\n",
         "  * Execute (and clear) with `withr::deferred_run()`.\n",
         "  * Clear (without executing) with `withr::deferred_clear()`."
       )
@@ -65,6 +65,7 @@ setup_handlers <- function(envir) {
 in_knitr <- function(envir) {
   knitr_in_progress() && identical(knitr::knit_global(), envir)
 }
+
 is_top_level_global_env <- function(envir) {
   if (!identical(envir, globalenv())) {
     return(FALSE)

--- a/R/compat-defer.R
+++ b/R/compat-defer.R
@@ -40,11 +40,18 @@ set_handlers <- function(envir, handlers) {
 }
 
 setup_handlers <- function(envir) {
-  if (identical(envir, .GlobalEnv)) {
+  in_knitr <- in_knitr(envir)
+
+  if (in_knitr || is_top_level_global_env(envir)) {
     # for global environment we use reg.finalizer()
     if (is_interactive()) {
+      if (in_knitr) {
+        ctxt <- "for the knitr document"
+      } else {
+        ctxt <- "on the global environment"
+      }
       message(
-        "Setting deferred event(s) on global environment.\n",
+        sprintf("Setting deferred event(s) %s.\n", ctxt),
         "  * Will be run automatically when session ends\n",
         "  * Execute (and clear) with `withr::deferred_run()`.\n",
         "  * Clear (without executing) with `withr::deferred_clear()`."
@@ -62,6 +69,18 @@ setup_handlers <- function(envir) {
   }
 }
 
+in_knitr <- function(envir) {
+  knitr_in_progress() && identical(knitr::knit_global(), envir)
+}
+is_top_level_global_env <- function(envir) {
+  if (!identical(envir, globalenv())) {
+    return(FALSE)
+  }
+
+  # Check if another global environment is on the stack
+  !any(vapply(sys.frames(), identical, NA, globalenv()))
+}
+
 get_handlers <- function(envir) {
   attr(envir, "withr_handlers")
 }
@@ -76,6 +95,7 @@ execute_handlers <- function(envir) {
       }
     )
   }
+  attr(envir, "withr_handlers") <- NULL
 
   for (error in errors) {
     stop(error)
@@ -92,13 +112,17 @@ is_interactive <- function() {
   if (!is.null(opt)) {
     return(opt)
   }
-  if (isTRUE(getOption("knitr.in.progress"))) {
+  if (knitr_in_progress()) {
     return(FALSE)
   }
   if (identical(Sys.getenv("TESTTHAT"), "true")) {
     return(FALSE)
   }
   interactive()
+}
+
+knitr_in_progress <- function() {
+  isTRUE(getOption("knitr.in.progress"))
 }
 
 }) # defer() namespace

--- a/tests/testthat/_snaps/defer.md
+++ b/tests/testthat/_snaps/defer.md
@@ -3,7 +3,7 @@
     Code
       defer(print("howdy"), envir = globalenv())
     Message <simpleMessage>
-      Setting deferred event(s) on global environment.
+      Setting deferred event(s) on the global environment.
         * Will be run automatically when session ends
         * Execute (and clear) with `withr::deferred_run()`.
         * Clear (without executing) with `withr::deferred_clear()`.

--- a/tests/testthat/_snaps/defer.md
+++ b/tests/testthat/_snaps/defer.md
@@ -4,7 +4,7 @@
       defer(print("howdy"), envir = globalenv())
     Message <simpleMessage>
       Setting deferred event(s) on the global environment.
-        * Will be run automatically when session ends
+        * Will be run automatically when session ends.
         * Execute (and clear) with `withr::deferred_run()`.
         * Clear (without executing) with `withr::deferred_clear()`.
 

--- a/tests/testthat/test-defer.R
+++ b/tests/testthat/test-defer.R
@@ -42,6 +42,18 @@ test_that("defer()'s global env facilities work", {
   expect_null(h)
 })
 
+test_that("non-top-level global env is unwound like a normal env", {
+  expect_silent(
+    evalq(local_options(list(opt = "foo")), globalenv())
+  )
+
+  # Check that handlers have been called
+  expect_null(getOption("opt"))
+
+  # Check that handlers were cleaned up
+  expect_null(get_handlers(globalenv()))
+})
+
 test_that("defered actions in global env are run on exit", {
   path <- local_tempfile()
   callr::r(


### PR DESCRIPTION
Closes #136
Follow-up to #187

- Consistently use session scope inside knitr, no matter the evaluation environment.
- Do not use session scope with non-top-level evaluations in the global environment.