### PR TITLE
Support `defer()` in `source()` and `knit()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # withr (development version)
 
+* `defer()` and `local_` functions now work within `source()`.
+
 * `with_namespace()` and `local_namespace()` now pass `warn.conflicts`
   to `attach()` (@kyleam, #185).
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,5 @@
 # withr (development version)
 
-* `defer()` and `local_` functions now work within `source()`.
-
 * `with_namespace()` and `local_namespace()` now pass `warn.conflicts`
   to `attach()` (@kyleam, #185).
 
@@ -54,11 +52,12 @@
 * `local_tempfile()` gains a lines argument so, if desired, you can pre-fill
   the temporary file with some data.
 
-* `defer()` and all `local_*()` functions now work when run inside of a
-  `.Rmd`. Note that they are executed at the very end of the session,
-  after the output has been collected, so you won't see any printed
-  side-effects (#187). The same applies with interactive knitting,
-  e.g. in notebooks. They are only executed when R exits.
+* `defer()` and all `local_*()` functions now work when run inside of
+  a `.Rmd`. The deferred expressions are executed after knitr has
+  returned.
+
+* `defer()` and `local_` functions now work within `source()`.
+
 
 # withr 2.4.3
 

--- a/R/compat-defer.R
+++ b/R/compat-defer.R
@@ -130,16 +130,16 @@ source_frame <- function(envir, frames, calls, frame_loc) {
   }
   calls <- as.list(calls)
 
-  if (!is_call(calls[[i - 0]], quote(eval))) {
-    return(NULL)
-  }
-  if (!is_call(calls[[i - 1]], quote(eval))) {
+  if (!is_call(calls[[i - 3]], quote(source))) {
     return(NULL)
   }
   if (!is_call(calls[[i - 2]], quote(withVisible))) {
     return(NULL)
   }
-  if (!is_call(calls[[i - 3]], quote(source))) {
+  if (!is_call(calls[[i - 1]], quote(eval))) {
+    return(NULL)
+  }
+  if (!is_call(calls[[i - 0]], quote(eval))) {
     return(NULL)
   }
 

--- a/R/compat-defer.R
+++ b/R/compat-defer.R
@@ -148,19 +148,17 @@ source_frame <- function(envir, frames, calls, frame_loc) {
 
 frame_loc <- function(envir, frames) {
   n <- length(frames)
+  if (!n) {
+    return(0)
+  }
 
-  found <- FALSE
   for (i in seq_along(frames)) {
     if (identical(frames[[n - i + 1]], envir)) {
-      found <- TRUE
-      break
+      return(n - i + 1)
     }
   }
-  if (found) {
-    n - i + 1
-  } else {
-    0
-  }
+
+  0
 }
 
 in_knitr <- function(envir) {

--- a/R/compat-defer.R
+++ b/R/compat-defer.R
@@ -26,18 +26,24 @@ new_handler <- function(expr, envir) {
   hnd
 }
 
-add_handler <- function(envir, handler, front) {
+add_handler <- function(envir,
+                        handler,
+                        front,
+                        frames = as.list(sys.frames()),
+                        calls = as.list(sys.calls())) {
+  envir <- exit_frame(envir, frames, calls)
+
   if (front) {
     handlers <- c(list(handler), get_handlers(envir))
   } else {
     handlers <- c(get_handlers(envir), list(handler))
   }
 
-  set_handlers(envir, handlers)
+  set_handlers(envir, handlers, frames = frames, calls = calls)
   handler
 }
 
-set_handlers <- function(envir, handlers) {
+set_handlers <- function(envir, handlers, frames, calls) {
   if (is.null(get_handlers(envir))) {
     # Ensure that list of handlers called when environment "ends"
     setup_handlers(envir)
@@ -46,8 +52,11 @@ set_handlers <- function(envir, handlers) {
   attr(envir, "withr_handlers") <- handlers
 }
 
-setup_handlers <- function(envir) {
-  if (in_knitr(envir) || is_top_level_global_env(envir)) {
+# Evaluate `frames` lazily
+setup_handlers <- function(envir,
+                           frames = as.list(sys.frames()),
+                           calls = as.list(sys.calls())) {
+  if (in_knitr(envir) || is_top_level_global_env(envir, frames)) {
     # For session scopes we use reg.finalizer()
     if (is_interactive()) {
       message(
@@ -66,7 +75,69 @@ setup_handlers <- function(envir) {
     # We have to use do.call here instead of eval because of the way on.exit
     # determines its evaluation context
     # (https://stat.ethz.ch/pipermail/r-devel/2013-November/067867.html)
+
     do.call(base::on.exit, list(call, TRUE), envir = envir)
+  }
+}
+
+exit_frame <- function(envir,
+                       frames = as.list(sys.frames()),
+                       calls = as.list(sys.calls())) {
+  frame_loc <- frame_loc(envir, frames)
+  if (!frame_loc) {
+    return(envir)
+  }
+
+  out <- source_frame(envir, frames, calls, frame_loc)
+  if (!is.null(out)) {
+    return(out)
+  }
+
+  envir
+}
+
+source_frame <- function(envir, frames, calls, frame_loc) {
+  i <- frame_loc
+
+  if (i < 4) {
+    return(NULL)
+  }
+
+  is_call <- function(x, fn) {
+    is.call(x) && identical(x[[1]], fn)
+  }
+  calls <- as.list(calls)
+
+  if (!is_call(calls[[i - 0]], quote(eval))) {
+    return(NULL)
+  }
+  if (!is_call(calls[[i - 1]], quote(eval))) {
+    return(NULL)
+  }
+  if (!is_call(calls[[i - 2]], quote(withVisible))) {
+    return(NULL)
+  }
+  if (!is_call(calls[[i - 3]], quote(source))) {
+    return(NULL)
+  }
+
+  frames[[i - 3]]
+}
+
+frame_loc <- function(envir, frames) {
+  n <- length(frames)
+
+  found <- FALSE
+  for (i in seq_along(frames)) {
+    if (identical(frames[[n - i + 1]], envir)) {
+      found <- TRUE
+      break
+    }
+  }
+  if (found) {
+    n - i + 1
+  } else {
+    0
   }
 }
 
@@ -74,13 +145,13 @@ in_knitr <- function(envir) {
   knitr_in_progress() && identical(knitr::knit_global(), envir)
 }
 
-is_top_level_global_env <- function(envir) {
+is_top_level_global_env <- function(envir, frames) {
   if (!identical(envir, globalenv())) {
     return(FALSE)
   }
 
   # Check if another global environment is on the stack
-  !any(vapply(sys.frames(), identical, NA, globalenv()))
+  !any(vapply(frames, identical, NA, globalenv()))
 }
 
 get_handlers <- function(envir) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -73,3 +73,18 @@ auto_splice <- function(x) {
     x
   }
 }
+
+browser <- function(...,
+                    skipCalls = 0,
+                    frame = parent.frame()) {
+  if (!identical(stdout(), getConnection(1))) {
+    sink(getConnection(1))
+    withr::defer(sink(), envir = frame)
+  }
+
+  # Calling `browser()` on exit avoids RStudio displaying the
+  # `browser2()` location. We still need one `n` to get to the
+  # expected place. Ideally `skipCalls` would not skip but exit the
+  # contexts.
+  on.exit(base::browser(..., skipCalls = skipCalls + 1))
+}

--- a/tests/testthat/test-defer.R
+++ b/tests/testthat/test-defer.R
@@ -122,3 +122,23 @@ test_that("defer works within source()", {
 
   expect_equal(out, c("1", "2", "bar", "3", "foo"))
 })
+
+test_that("defer works within knitr::knit()", {
+  out <- NULL
+  evalq({
+    defer(out <- c(out, "first"))
+    rmd <- "
+      ```{r}
+      defer(out <- c(out, 'foo'))
+      out <- c(out, '1')
+      ```
+      ```{r}
+      defer(out <- c(out, 'bar'))
+      out <- c(out, '2')
+      ```
+    "
+    knitr::knit(text = rmd, quiet = TRUE)
+    defer(out <- c(out, "last"))
+  })
+  expect_equal(out, c("1", "2", "bar", "foo", "last", "first"))
+})

--- a/tests/testthat/test-defer.R
+++ b/tests/testthat/test-defer.R
@@ -141,6 +141,42 @@ test_that("defer works within source()", {
   ))
 })
 
+test_that("defer works within source()", {
+  out <- NULL
+
+  file1 <- local_tempfile()
+  file2 <- local_tempfile()
+
+  cat(file = file1, "
+    out <<- c(out, 'outer-1')
+    defer(out <<- c(out, 'outer-before'))
+    out <<- c(out, 'outer-2')
+    local(source(file2, local = TRUE))
+    defer(out <<- c(out, 'outer-after'))
+    out <<- c(out, 'outer-3')
+  ")
+  cat(file = file2, "
+    out <<- c(out, '1')
+    defer(out <<- c(out, 'defer'))
+    out <<- c(out, '2')
+  ")
+
+  local(
+    source(file1, local = TRUE)
+  )
+
+  expect_equal(out, c(
+    "outer-1",
+    "outer-2",
+    "1",
+    "2",
+    "defer",
+    "outer-3",
+    "outer-after",
+    "outer-before"
+  ))
+})
+
 test_that("defer works within knitr::knit()", {
   out <- NULL
   evalq({

--- a/tests/testthat/test-defer.R
+++ b/tests/testthat/test-defer.R
@@ -104,3 +104,21 @@ test_that("defer executes all handlers even if there is an error in one of them"
 
   expect_equal(getOption("test_option"), 2)
 })
+
+test_that("defer works within source()", {
+  file <- local_tempfile()
+
+  out <- NULL
+  cat(file = file, "
+    out <<- c(out, '1')
+    defer(out <<- c(out, 'foo'))
+    out <<- c(out, '2')
+    evalq(defer(out <<- c(out, 'bar')))
+    out <<- c(out, '3')
+  ")
+  local(
+    source(file, local = TRUE)
+  )
+
+  expect_equal(out, c("1", "2", "bar", "3", "foo"))
+})


### PR DESCRIPTION
Following Jenny's suggestion about "document scope", and Hadley's suggested implementation, `defer()` within `source()` and `knitr::knit()` now detects the relevant frame to register deferred expressions. This way, expressions are executed when `source()` and `knit()` return. In Rmd documents this gives `local_` functions "document scope" rather than "session scope".

The detection of `source()` adds 10 microseconds to every `defer()` call on an empty stack:

```r
bench::mark(
  defer = local(defer(NULL))
)[1:8]

#> # main
#>   expression      min median `itr/sec` mem_alloc `gc/sec` n_itr  n_gc
#>   <bch:expr> <bch:tm> <bch:>     <dbl> <bch:byt>    <dbl> <int> <dbl>
#> 1 defer        17.2µs 18.7µs    46136.      280B     41.6  9991     9

#> # PR
#>   expression      min median `itr/sec` mem_alloc `gc/sec` n_itr  n_gc
#>   <bch:expr> <bch:tm> <bch:>     <dbl> <bch:byt>    <dbl> <int> <dbl>
#> 1 defer        26.7µs 28.6µs    31458.      280B     47.3  9985    15
```

and about 25 on a stack of about 50 frames:

```r
f <- function(n) {
  if (n) {
    f(n - 1)
  } else {
    defer(NULL)
  }
}

bench::mark(
  defer = f(50)
)[1:8]

#> # main
#>   expression      min median `itr/sec` mem_alloc `gc/sec` n_itr  n_gc
#>   <bch:expr> <bch:tm> <bch:>     <dbl> <bch:byt>    <dbl> <int> <dbl>
#> 1 defer        25.9µs 27.3µs    32594.        0B     42.4  9987    13

#> # PR
#>   expression      min median `itr/sec` mem_alloc `gc/sec` n_itr  n_gc
#>   <bch:expr> <bch:tm> <bch:>     <dbl> <bch:byt>    <dbl> <int> <dbl>
#> 1 defer        51.5µs 53.8µs    18078.     111KB     50.0  8316    23
```