### PR TITLE
more robust with_package/local_package

### DIFF
--- a/R/namespace.R
+++ b/R/namespace.R
@@ -22,20 +22,11 @@ with_package <- function(package, code, pos = 2, lib.loc = NULL,
   character.only = TRUE, logical.return = FALSE, warn.conflicts = FALSE,
   quietly = TRUE, verbose = getOption("verbose")) {
 
-  # Only try to attach (and detach) the package if it is not already attached.
-  if (!(package %in% .packages())) {
-    suppressPackageStartupMessages(
-      (get("library"))(package, pos = pos, lib.loc = lib.loc,
-        character.only = character.only, logical.return = logical.return,
-        warn.conflicts = warn.conflicts, quietly = quietly, verbose = verbose))
-
-    defer({
-      if (package %in% .packages()) {
-        detach(paste0("package:", package), character.only = TRUE)
-      }
-    })
-  }
-
+  local_package(package = package, pos = pos, lib.loc = lib.loc,
+                character.only = character.only,
+                logical.return = logical.return,
+                warn.conflicts = warn.conflicts,
+                quietly = quietly, verbose = verbose)
   force(code)
 }
 

--- a/R/namespace.R
+++ b/R/namespace.R
@@ -29,7 +29,11 @@ with_package <- function(package, code, pos = 2, lib.loc = NULL,
         character.only = character.only, logical.return = logical.return,
         warn.conflicts = warn.conflicts, quietly = quietly, verbose = verbose))
 
-    on.exit(detach(paste0("package:", package), character.only = TRUE))
+    defer({
+      if (package %in% .packages()) {
+        detach(paste0("package:", package), character.only = TRUE)
+      }
+    })
   }
 
   force(code)
@@ -42,12 +46,18 @@ local_package <- function(package, pos = 2, lib.loc = NULL,
   quietly = TRUE, verbose = getOption("verbose"),
   .local_envir = parent.frame()) {
 
-  suppressPackageStartupMessages(
-    (get("library"))(package, pos = pos, lib.loc = lib.loc,
-      character.only = character.only, logical.return = logical.return,
-      warn.conflicts = warn.conflicts, quietly = quietly, verbose = verbose))
+  if (!(package %in% .packages())) {
+    suppressPackageStartupMessages(
+      (get("library"))(package, pos = pos, lib.loc = lib.loc,
+        character.only = character.only, logical.return = logical.return,
+        warn.conflicts = warn.conflicts, quietly = quietly, verbose = verbose))
 
-  defer(detach(paste0("package:", package), character.only = TRUE), envir = .local_envir)
+    defer({
+      if (package %in% .packages()) {
+        detach(paste0("package:", package), character.only = TRUE)
+      }
+    }, envir = .local_envir)
+  }
 }
 
 #' @rdname with_package

--- a/tests/testthat/test-namespace.R
+++ b/tests/testthat/test-namespace.R
@@ -30,6 +30,23 @@ test_that("local_package works", {
   expect_false("package:tools" %in% search())
 })
 
+test_that("local_package does not unload previously loaded package", {
+  with_package("tools", {
+    # tools package is attached to the search path
+    expect_true("package:tools" %in% search())
+
+    f <- function() {
+      local_package("tools")
+      expect_true("package:tools" %in% search())
+    }
+
+    f()
+
+    # tools package is still attached to the search path
+    expect_true("package:tools" %in% search())
+  })
+})
+
 test_that("with_namespace works", {
 
   # tools package not attached to the search path


### PR DESCRIPTION
Even if package x was already attached when calling `local_package(x)` x was still detached at the end of the current execution context. This is confusing, because `local_*` functions should ideally restore the same global state as before. `with_package` already had a check for that, and with this PR the same check is used for `local_package`. Furthermore `with_package` is now implemented using `local_package` to reduce code duplication. This is also removes the `on.exit` that `with_package` was using instead of `defer`.