### PR TITLE
Document the return value of `with_(set=)`

### DIFF
--- a/R/with_.R
+++ b/R/with_.R
@@ -16,6 +16,8 @@ NULL
 #' @inheritParams rlang::args_dots_empty
 #'
 #' @param set `[function(...)]`\cr Function used to set the state.
+#'   The return value from this function should be the old state, which will
+#'   then be passed back into the `reset()` function to clean up the state.
 #'   The function can have arbitrarily many arguments, they will be replicated
 #'   in the formals of the returned function.
 #' @param reset `[function(x)]`\cr Function used to reset the state.

--- a/man/with_.Rd
+++ b/man/with_.Rd
@@ -19,6 +19,8 @@ with_(set, reset = set, get = NULL, ..., envir = parent.frame(), new = TRUE)
 }
 \arguments{
 \item{set}{\verb{[function(...)]}\cr Function used to set the state.
+The return value from this function should be the old state, which will
+then be passed back into the \code{reset()} function to clean up the state.
 The function can have arbitrarily many arguments, they will be replicated
 in the formals of the returned function.}
 


### PR DESCRIPTION
It wasn't previously clear what the return value of the `set` parameter should be.