### PR TITLE
Explicitly specify `choices` for `match.arg()`

### DIFF
--- a/R/compat-defer.R
+++ b/R/compat-defer.R
@@ -3,6 +3,9 @@
 # This drop-in file implements withr::defer(). Please find the most
 # recent version in withr's repository.
 #
+# 2023-03-08
+# * Explicitly specified `choices` in `match.arg()`, for performance.
+#
 # 2022-03-03
 # * Support for `source()` and `knitr::knit()`
 # * Handlers are now stored in environments instead of lists to avoid

--- a/R/compat-defer.R
+++ b/R/compat-defer.R
@@ -15,7 +15,7 @@ defer <- function(expr, envir = parent.frame(), priority = c("first", "last")) {
 local({
 
 defer <<- defer <- function(expr, envir = parent.frame(), priority = c("first", "last")) {
-  priority <- match.arg(priority)
+  priority <- match.arg(priority, choices = c("first", "last"))
   invisible(
     add_handler(
       envir,


### PR DESCRIPTION
Specifying `choices` is slightly faster than letting `match.arg()` look it up

``` r
fn1 <- function(x = c("a", "b", "c")) {
  match.arg(x)
}
fn2 <- function(x = c("a", "b", "c")) {
  match.arg(x, choices = c("a", "b", "c"))
}

bench::mark(
  fn1(),
  fn2(),
  iterations = 100000
)
#> # A tibble: 2 × 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 fn1()        6.82µs   7.75µs   115941.        0B     13.9
#> 2 fn2()        2.43µs   2.78µs   324765.        0B     19.5
```