### PR TITLE
Small reorganization of handler internals

### DIFF
--- a/R/compat-defer.R
+++ b/R/compat-defer.R
@@ -3,6 +3,9 @@
 # This drop-in file implements withr::defer(). Please find the most
 # recent version in withr's repository.
 #
+# 2023-03-08
+# * Small internal tweaks related to frame evaluation and passing arguments.
+#
 # 2022-03-03
 # * Support for `source()` and `knitr::knit()`
 # * Handlers are now stored in environments instead of lists to avoid


### PR DESCRIPTION
A few small tweaks to the handler internals. A few are related to performance, but many are just related to code hygiene. I'll point them out inline.

The biggest performance hits in withr seem to be:
- The loop in `frame_loc()` that uses `identical()` to check for equal environments
- The loop in `execute_handlers()` that repeatedly calls `tryCatch()`

Unfortunately I don't think there is much we can do to improve these. A C level `tryCatch()` would help a lot though, if we ever get that.

Hard to see a concrete amount of improvement here directly:

```r
fn <- function() {
  defer(1)
  NULL
}

bench::mark(fn(), iterations = 1000000)

# dev withr
#> # A tibble: 1 × 13
#>   expression      min median `itr/sec` mem_alloc `gc/sec`  n_itr  n_gc total_time result memory    
#>   <bch:expr> <bch:tm> <bch:>     <dbl> <bch:byt>    <dbl>  <int> <dbl>   <bch:tm> <list> <list>    
#> 1 fn()           47µs 61.4µs    15857.    30.8KB     18.4 998840  1160      1.05m <NULL> <Rprofmem>
#> # … with 2 more variables: time <list>, gc <list>

# This PR
#> # A tibble: 1 × 13
#>   expression      min median `itr/sec` mem_alloc `gc/sec`  n_itr  n_gc total_time result memory    
#>   <bch:expr> <bch:tm> <bch:>     <dbl> <bch:byt>    <dbl>  <int> <dbl>   <bch:tm> <list> <list>    
#> 1 fn()         45.6µs 58.1µs    17001.    95.1KB     18.8 998895  1105      58.8s <NULL> <Rprofmem>
#> # … with 2 more variables: time <list>, gc <list>
```

But if you install this PR of withr + patch the updated compat file into rlang and install that patched version of rlang, then these dev tidyselect benchmarks do show an improvement (because tidyselect internally calls `defer()` quite a few times):

(the "before" runs all use dev tidyselect, dev rlang, and dev withr to provide an accurate comparison)

```r
library(tidyselect)
library(tidyselect)
library(rlang)
 
expr <- expr(c(mpg, cyl))
bench::mark(eval_select(expr, mtcars), iterations = 50000)

# This PR
#> # A tibble: 1 × 13
#>   expression                  min median `itr/sec` mem_alloc `gc/sec` n_itr  n_gc total_time result memory    
#>   <bch:expr>                <bch> <bch:>     <dbl> <bch:byt>    <dbl> <int> <dbl>   <bch:tm> <list> <list>    
#> 1 eval_select(expr, mtcars) 632µs  760µs     1315.    3.44MB     12.3 49537   463      37.7s <int>  <Rprofmem>
#> # … with 2 more variables: time <list>, gc <list>

# Dev withr
#> # A tibble: 1 × 13
#>   expression                  min median `itr/sec` mem_alloc `gc/sec` n_itr  n_gc total_time result memory    
#>   <bch:expr>                <bch> <bch:>     <dbl> <bch:byt>    <dbl> <int> <dbl>   <bch:tm> <list> <list>    
#> 1 eval_select(expr, mtcars) 622µs  798µs     1263.     3.1MB     14.6 49430   570      39.1s <int>  <Rprofmem>
#> # … with 2 more variables: time <list>, gc <list>
 
expr <- expr(mpg)
bench::mark(eval_select(expr, mtcars), iterations = 50000)

# This PR
#> # A tibble: 1 × 13
#>   expression                  min median `itr/sec` mem_alloc `gc/sec` n_itr  n_gc total_time result memory    
#>   <bch:expr>                <bch> <bch:>     <dbl> <bch:byt>    <dbl> <int> <dbl>   <bch:tm> <list> <list>    
#> 1 eval_select(expr, mtcars) 468µs  551µs     1801.    2.05KB     12.5 49656   344      27.6s <int>  <Rprofmem>
#> # … with 2 more variables: time <list>, gc <list>

# Dev withr
#> # A tibble: 1 × 13
#>   expression                  min median `itr/sec` mem_alloc `gc/sec` n_itr  n_gc total_time result memory    
#>   <bch:expr>                <bch> <bch:>     <dbl> <bch:byt>    <dbl> <int> <dbl>   <bch:tm> <list> <list>    
#> 1 eval_select(expr, mtcars) 475µs  593µs     1706.    2.05KB     16.6 49518   482        29s <int>  <Rprofmem>
#> # … with 2 more variables: time <list>, gc <list>
 
expr <- expr(starts_with("d") | c(mpg, cyl))
bench::mark(eval_select(expr, mtcars), iterations = 50000)

# This PR
#> # A tibble: 1 × 13
#>   expression                  min median `itr/sec` mem_alloc `gc/sec` n_itr  n_gc total_time result memory    
#>   <bch:expr>                <bch> <bch:>     <dbl> <bch:byt>    <dbl> <int> <dbl>   <bch:tm> <list> <list>    
#> 1 eval_select(expr, mtcars) 742µs  908µs     1116.     114KB     12.4 49452   548      44.3s <int>  <Rprofmem>
#> # … with 2 more variables: time <list>, gc <list>

# Dev withr
#> # A tibble: 1 × 13
#>   expression                  min median `itr/sec` mem_alloc `gc/sec` n_itr  n_gc total_time result memory    
#>   <bch:expr>                <bch> <bch:>     <dbl> <bch:byt>    <dbl> <int> <dbl>   <bch:tm> <list> <list>    
#> 1 eval_select(expr, mtcars) 754µs  924µs     1092.     113KB     16.7 49247   753      45.1s <int>  <Rprofmem>
#> # … with 2 more variables: time <list>, gc <list>
 
expr <- expr(starts_with("d") & !where(is.numeric))
bench::mark(eval_select(expr, mtcars), iterations = 50000)

# This PR
#> # A tibble: 1 × 13
#>   expression                  min median `itr/sec` mem_alloc `gc/sec` n_itr  n_gc total_time result memory    
#>   <bch:expr>                <bch> <bch:>     <dbl> <bch:byt>    <dbl> <int> <dbl>   <bch:tm> <list> <list>    
#> 1 eval_select(expr, mtcars) 707µs  870µs     1167.     198KB     12.9 49453   547      42.4s <int>  <Rprofmem>
#> # … with 2 more variables: time <list>, gc <list>

# Dev withr
#> # A tibble: 1 × 13
#>   expression                  min median `itr/sec` mem_alloc `gc/sec` n_itr  n_gc total_time result memory    
#>   <bch:expr>                <bch> <bch:>     <dbl> <bch:byt>    <dbl> <int> <dbl>   <bch:tm> <list> <list>    
#> 1 eval_select(expr, mtcars) 715µs  881µs     1149.     166KB     17.4 49256   744      42.9s <int>  <Rprofmem>
#> # … with 2 more variables: time <list>, gc <list>
 
expr <- expr(starts_with("d") | starts_with("m") | starts_with("v"))
bench::mark(eval_select(expr, mtcars), iterations = 50000)

# This PR
#> # A tibble: 1 × 13
#>   expression                  min median `itr/sec` mem_alloc `gc/sec` n_itr  n_gc total_time result memory    
#>   <bch:expr>                <bch> <bch:>     <dbl> <bch:byt>    <dbl> <int> <dbl>   <bch:tm> <list> <list>    
#> 1 eval_select(expr, mtcars) 701µs  852µs     1189.    2.05KB     12.3 49488   512      41.6s <int>  <Rprofmem>
#> # … with 2 more variables: time <list>, gc <list>

# Dev withr
#> # A tibble: 1 × 13
#>   expression                  min median `itr/sec` mem_alloc `gc/sec` n_itr  n_gc total_time result memory    
#>   <bch:expr>                <bch> <bch:>     <dbl> <bch:byt>    <dbl> <int> <dbl>   <bch:tm> <list> <list>    
#> 1 eval_select(expr, mtcars) 709µs  887µs     1126.    2.05KB     15.9 49302   698      43.8s <int>  <Rprofmem>
#> # … with 2 more variables: time <list>, gc <list>
```