### PR TITLE
Disable `source()` support by default

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # withr (development version)
 
+* `source()` support now requires setting `options(withr.hook_source = TRUE)`.
+  It is disabled by default to avoid a performance penalty when not needed.
+
 # withr 2.5.0
 
 * `defer()` and all `local_*()` functions now work when run inside of

--- a/R/defer.R
+++ b/R/defer.R
@@ -18,8 +18,13 @@ defer_ns <- environment(defer)
 #' be executed `"first"` or `"last"`, relative to any other
 #' registered handlers on this environment.
 #'
-#' @details
+#' @section Running handlers within `source()`:
+#' `r lifecycle::badge("experimental")` Set `options(withr.hook_source
+#' = TRUE)` to enable top-level usage of withr tools in scripts
+#' sourced with `base::source()`. The cleanup expressions are run when
+#' `source()` exits (either normally or early due to an error).
 #'
+#' @details
 #' `defer()` works by attaching handlers to the requested environment (as an
 #' attribute called `"handlers"`), and registering an exit handler that
 #' executes the registered handler when the function associated with the

--- a/man/defer.Rd
+++ b/man/defer.Rd
@@ -45,6 +45,13 @@ function or test. A message alerts the user to the fact that an explicit
 \code{deferred_clear()} to clear them without evaluation. The global environment
 scenario is the main motivation for these functions.
 }
+\section{Running handlers within \code{source()}}{
+
+\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}} Set \code{options(withr.hook_source = TRUE)} to enable top-level usage of withr tools in scripts
+sourced with \code{base::source()}. The cleanup expressions are run when
+\code{source()} exits (either normally or early due to an error).
+}
+
 \examples{
 # define a 'local' function that creates a file, and
 # removes it when the parent function has finished executing

--- a/tests/testthat/test-standalone-defer.R
+++ b/tests/testthat/test-standalone-defer.R
@@ -111,6 +111,8 @@ test_that("defer executes all handlers even if there is an error in one of them"
 })
 
 test_that("defer works within source()", {
+  local_options(withr.hook_source = TRUE)
+
   file <- local_tempfile()
   out <- NULL
 
@@ -147,6 +149,8 @@ test_that("defer works within source()", {
 })
 
 test_that("defer works within source()", {
+  local_options(withr.hook_source = TRUE)
+
   out <- NULL
 
   file1 <- local_tempfile()


### PR DESCRIPTION
To avoid the overhead of analysing the call stack:

```r
# CRAN
bench::mark(g())[1:8]
#> # A tibble: 1 × 8
#>   expression      min   median `itr/sec` mem_al…¹ gc/se…² n_itr  n_gc
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:by>   <dbl> <int> <dbl>
#> 1 g()          55.6µs   59.2µs    15687.     688B    32.4  7263    15

# `source()` disabled by default
bench::mark(g())[1:8]
#> # A tibble: 1 × 8
#>   expression      min   median `itr/sec` mem_al…¹ gc/se…² n_itr  n_gc
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:by>   <dbl> <int> <dbl>
#> 1 g()          18.4µs   19.6µs    50007.    182KB    150.  9970    30
```

cc @hadley and @DavisVaughan 