### PR TITLE
Implement `defer()` on top of `on.exit()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -42,7 +42,7 @@ URL: https://withr.r-lib.org,
     https://github.com/r-lib/withr#readme
 BugReports: https://github.com/r-lib/withr/issues
 Depends:
-    R (>= 3.2.0)
+    R (>= 3.5.0)
 Imports:
     graphics,
     grDevices,

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,7 +3,7 @@
 * `defer()` is now a thin wrapper around `base::on.exit()`. This is
   possible thanks to two contributions that we made to R 3.5:
 
-  - We added an argument for FIFO cleanup: `on.exit(after = FALSE)`
+  - We added an argument for FIFO cleanup: `on.exit(after = FALSE)`.
   - Calling `sys.on.exit()` elsewhere than top-level didn't work. This
     is needed for manual invokation with `deferred_run()`.
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,18 @@
 # withr (development version)
 
+* `defer()` is now a thin wrapper around `base::on.exit()`. This is
+  possible thanks to two contributions that we made to R 3.5:
+
+  - We added an argument for FIFO cleanup: `on.exit(after = FALSE)`
+  - Calling `sys.on.exit()` elsewhere than top-level didn't work. This
+    is needed for manual invokation with `deferred_run()`.
+
+  Following this change, `defer()` is now much faster (although still
+  slower than `on.exit()`). This also increases the compatibility of
+  `defer()` with `on.exit()` (all handlers are now run in the expected
+  order even if they are registered with `on.exit()`) and standalone
+  versions of `defer()`.
+
 * `source()` support now requires setting `options(withr.hook_source = TRUE)`.
   It is disabled by default to avoid a performance penalty when not needed.
 

--- a/R/defer.R
+++ b/R/defer.R
@@ -79,10 +79,7 @@ defer <- function(expr, envir = parent.frame(), priority = c("first", "last")) N
 #' @rdname defer
 #' @export
 defer_parent <- function(expr, priority = c("first", "last")) {
-  eval(substitute(
-    defer(expr, envir, priority),
-    list(expr = substitute(expr), envir = parent.frame(2), priority = priority, defer = defer)
-  ), envir = parent.frame())
+  defer(expr, parent.frame(2), priority = priority)
 }
 
 #' @rdname defer

--- a/R/defer.R
+++ b/R/defer.R
@@ -100,6 +100,10 @@ deferred_run <- function(envir = parent.frame()) {
 frame_exits <- function(frame = parent.frame()) {
   exits <- do.call(sys.on.exit, list(), envir = frame)
 
+  # The exit expressions are stored in a single object that is
+  # evaluated on exit. This can be NULL, an expression, or multiple
+  # expressions wrapped in {. We convert this data structure to a list
+  # of expressions.
   if (is.null(exits)) {
     list()
   } else if (identical(exits[[1]], quote(`{`))) {

--- a/R/defer.R
+++ b/R/defer.R
@@ -74,7 +74,7 @@ defer_ns <- environment(defer)
 #' defer(print("three"))
 #' deferred_clear()
 #' deferred_run()
-defer <- function(expr, envir = parent.frame(), priority = c("first", "last")) NULL
+defer
 
 #' @rdname defer
 #' @export

--- a/R/seed.R
+++ b/R/seed.R
@@ -79,13 +79,14 @@ with_preserve_seed <- function(code) {
 local_preserve_seed <- function(.local_envir = parent.frame()) {
   old_seed <- get_seed()
 
-  defer({
+  defer(
     if (is.null(old_seed)) {
-      on.exit(rm_seed(), add = TRUE)
+      rm_seed()
     } else {
-      on.exit(set_seed(old_seed), add = TRUE)
-    }
-  }, envir = .local_envir)
+      set_seed(old_seed)
+    },
+    envir = .local_envir
+  )
 
   invisible(old_seed)
 }

--- a/R/standalone-defer.R
+++ b/R/standalone-defer.R
@@ -9,11 +9,13 @@
 #
 # ## Changelog
 #
-# 2023-03-21:
+# 2023-03-22:
 # * Now uses standalone format for compatibility with
 #   `usethis::use_standalone()`.
 # * `source()` support is disabled by default for performance.
 #   Use `options(withr.hook_source = TRUE)` to enable it.
+# * `defer()` is now implemented on top of `on.exit()` for performance
+#   and forward compatibility.
 #
 # 2023-03-08:
 # * Explicitly specified `choices` in `match.arg()`, for performance.
@@ -42,55 +44,25 @@ defer <<- defer <- function(expr, envir = parent.frame(), priority = c("first", 
   }
 
   priority <- match.arg(priority, choices = c("first", "last"))
-  invisible(
-    add_handler(
-      envir,
-      handler = new_handler(substitute(expr), parent.frame()),
-      front = priority == "first"
-    )
+  after <- priority == "last"
+
+  thunk <- as.call(list(function() expr))
+  envir <- exit_frame(envir)
+
+  do.call(
+    base::on.exit,
+    list(thunk, TRUE, after),
+    envir = envir
   )
 }
 
-new_handler <- function(expr, envir) {
-  hnd <- new.env(FALSE, size = 2)
-  hnd[["expr"]] <- expr
-  hnd[["envir"]] <- envir
-  hnd
-}
-
-add_handler <- function(envir,
-                        handler,
-                        front,
-                        frames = as.list(sys.frames()),
-                        calls = as.list(sys.calls())) {
-  envir <- exit_frame(envir, frames, calls)
-
-  if (front) {
-    handlers <- c(list(handler), get_handlers(envir))
-  } else {
-    handlers <- c(get_handlers(envir), list(handler))
+is_top_level_global_env <- function(envir, frames = sys.frames()) {
+  if (!identical(envir, globalenv())) {
+    return(FALSE)
   }
 
-  set_handlers(envir, handlers, frames = frames, calls = calls)
-  handler
-}
-
-set_handlers <- function(envir, handlers, frames, calls) {
-  if (is.null(get_handlers(envir))) {
-    # Ensure that list of handlers called when environment "ends"
-    setup_handlers(envir)
-  }
-
-  attr(envir, "withr_handlers") <- handlers
-}
-
-setup_handlers <- function(envir) {
-  call <- make_call(execute_handlers, envir)
-  # We have to use do.call here instead of eval because of the way on.exit
-  # determines its evaluation context
-  # (https://stat.ethz.ch/pipermail/r-devel/2013-November/067867.html)
-
-  do.call(base::on.exit, list(call, TRUE), envir = envir)
+  # Check if another global environment is on the stack
+  !any(vapply(frames, identical, NA, globalenv()))
 }
 
 exit_frame <- function(envir,
@@ -185,14 +157,8 @@ frame_loc <- function(envir, frames) {
 in_knitr <- function(envir) {
   knitr_in_progress() && identical(knitr::knit_global(), envir)
 }
-
-is_top_level_global_env <- function(envir, frames = sys.frames()) {
-  if (!identical(envir, globalenv())) {
-    return(FALSE)
-  }
-
-  # Check if another global environment is on the stack
-  !any(vapply(frames, identical, NA, globalenv()))
+knitr_in_progress <- function() {
+  isTRUE(getOption("knitr.in.progress"))
 }
 
 get_handlers <- function(envir) {
@@ -214,29 +180,6 @@ execute_handlers <- function(envir) {
   for (error in errors) {
     stop(error)
   }
-}
-
-make_call <- function(...) {
-  as.call(list(...))
-}
-
-# base implementation of rlang::is_interactive()
-is_interactive <- function() {
-  opt <- getOption("rlang_interactive")
-  if (!is.null(opt)) {
-    return(opt)
-  }
-  if (knitr_in_progress()) {
-    return(FALSE)
-  }
-  if (identical(Sys.getenv("TESTTHAT"), "true")) {
-    return(FALSE)
-  }
-  interactive()
-}
-
-knitr_in_progress <- function() {
-  isTRUE(getOption("knitr.in.progress"))
 }
 
 }) # defer() namespace

--- a/R/standalone-defer.R
+++ b/R/standalone-defer.R
@@ -161,27 +161,6 @@ knitr_in_progress <- function() {
   isTRUE(getOption("knitr.in.progress"))
 }
 
-get_handlers <- function(envir) {
-  attr(envir, "withr_handlers")
-}
-
-execute_handlers <- function(envir) {
-  handlers <- get_handlers(envir)
-  errors <- list()
-  for (handler in handlers) {
-    tryCatch(eval(handler$expr, handler$envir),
-      error = function(e) {
-        errors[[length(errors) + 1]] <<- e
-      }
-    )
-  }
-  attr(envir, "withr_handlers") <- NULL
-
-  for (error in errors) {
-    stop(error)
-  }
-}
-
 }) # defer() namespace
 
 # nocov end

--- a/R/standalone-defer.R
+++ b/R/standalone-defer.R
@@ -33,7 +33,7 @@ defer <- function(expr, envir = parent.frame(), priority = c("first", "last")) {
 
 local({
 
-defer <<- defer <- function(expr, envir = parent.frame(), priority = c("first", "last")) {
+defer <- function(expr, envir = parent.frame(), priority = c("first", "last")) {
   if (is_top_level_global_env(envir)) {
     # Do nothing if withr is not installed, just like `on.exit()`
     # called in the global env
@@ -55,6 +55,10 @@ defer <<- defer <- function(expr, envir = parent.frame(), priority = c("first", 
     envir = envir
   )
 }
+
+# Inline formals
+formals(defer)[["priority"]] <- eval(formals(defer)[["priority"]])
+defer <<- defer
 
 is_top_level_global_env <- function(envir, frames = sys.frames()) {
   if (!identical(envir, globalenv())) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -78,3 +78,18 @@ setNames <- function(x = nm, nm) {
   names(x) <- nm
   x
 }
+
+# base implementation of rlang::is_interactive()
+is_interactive <- function() {
+  opt <- getOption("rlang_interactive")
+  if (!is.null(opt)) {
+    return(opt)
+  }
+  if (knitr_in_progress()) {
+    return(FALSE)
+  }
+  if (identical(Sys.getenv("TESTTHAT"), "true")) {
+    return(FALSE)
+  }
+  interactive()
+}

--- a/tests/testthat/test-defer.R
+++ b/tests/testthat/test-defer.R
@@ -1,0 +1,13 @@
+test_that("`frame_exits()` and `frame_clear_exits()`", {
+  on.exit("foo")
+  expect_equal(frame_exits(), list("foo"))
+
+  on.exit("bar", add = TRUE)
+  expect_equal(frame_exits(), list("foo", "bar"))
+
+  on.exit("baz", add = TRUE, after = FALSE)
+  expect_equal(frame_exits(), list("baz", "foo", "bar"))
+
+  frame_clear_exits()
+  expect_equal(frame_exits(), list())
+})

--- a/tests/testthat/test-standalone-defer.R
+++ b/tests/testthat/test-standalone-defer.R
@@ -18,7 +18,8 @@ test_that("defer_parent works", {
 })
 
 test_that("defer()'s global env facilities work", {
-  expect_null(get_handlers(globalenv()))
+  expect_length(the$global_exits, 0)
+
   local_options(rlang_interactive = TRUE)
   Sys.setenv(abcdefg = "abcdefg")
 
@@ -53,7 +54,7 @@ test_that("non-top-level global env is unwound like a normal env", {
   expect_null(getOption("opt"))
 
   # Check that handlers were cleaned up
-  expect_null(get_handlers(globalenv()))
+  expect_length(the$global_exits, 0)
 })
 
 test_that("defered actions in global env are run on exit", {

--- a/tests/testthat/test-standalone-defer.R
+++ b/tests/testthat/test-standalone-defer.R
@@ -221,3 +221,17 @@ test_that("defer works within knitr::knit()", {
     "first"
   ))
 })
+
+test_that("defer() and on.exit() handlers can be meshed", {
+  out <- list()
+
+  local({
+    on.exit(out <<- append(out, 1), add = TRUE)
+    defer(out <<- append(out, 2))
+    on.exit(out <<- append(out, 3), add = TRUE)
+    on.exit(out <<- append(out, 4), add = TRUE, after = FALSE)
+    defer(out <<- append(out, 5), priority = "last")
+  })
+
+  expect_equal(out, list(4, 2, 1, 3, 5))
+})


### PR DESCRIPTION
Branched from #220.

With this rewrite `defer()` is now a thin layer on top of `on.exit()`. This is possible thanks to two contributions that we made to R 3.5:

- Added argument for FIFO cleanup: `on.exit(after = FALSE)`
- Calling `sys.on.exit()` elsewhere than top-level didn't work. This is needed for manual invokation with `deferred_run()`.

Because of this change all users of the standalone file now need to update their file. Until they do, the order of execution of `defer()`-based handlers from different packages will not be correct because they no longer share the same data structure. I'm only aware of rlang and @gaborcsardi's packages that use a standalone defer.

One benefit of switching to `on.exit()` is that everything now shares the same data structure implemented in the R call stack. This should fix forward-compatibility issues with standalone `defer()`, and more generally make `defer()` compatible with `on.exit()` and other wrappers of `on.exit()`.

The other benefit is increased performance, cc @DavisVaughan:

```r
library(withr)

base <- function() on.exit(NULL)
withr <- function() defer(NULL)

# CRAN
bench::mark(base(), withr(), check = FALSE)[1:8]
#> # A tibble: 2 × 8
#>   expression      min   median `itr/sec` mem_al…¹ gc/se…² n_itr  n_gc
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:by>   <dbl> <int> <dbl>
#> 1 base()         41ns  123.1ns  4576094.       0B      0  10000     0
#> 2 withr()      24.9µs   26.3µs    37077.   28.8KB    213.  9943    57

# With `source()` disabled by default
bench::mark(base(), withr(), check = FALSE)[1:8]
#> # A tibble: 2 × 8
#>   expression      min   median `itr/sec` mem_al…¹ gc/se…² n_itr  n_gc
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:by>   <dbl> <int> <dbl>
#> 1 base()         41ns  123.1ns   710408.       0B      0  10000     0
#> 2 withr()      13.6µs   14.5µs    67197.   93.3KB    209.  9969    31

# This PR
#> # A tibble: 2 × 8
#>   expression      min   median `itr/sec` mem_al…¹ gc/se…² n_itr  n_gc
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:by>   <dbl> <int> <dbl>
#> 1 base()      82.02ns 205.07ns  4261544.       0B     0   10000     0
#> 2 withr()      3.81µs   4.47µs   216726.       0B    43.4  9998     2
```

The remaining of the time is spent in `identical()` (to detect global envs) and `match.arg()`.

```r
prof_tbl(for (i in 1:10000) withr())
#> # A tibble: 8 × 5
#>   fn                      total.time total.pct self.time self.pct
#>   <chr>                        <dbl>     <dbl>     <dbl>    <dbl>
#> 1 identical                     0.02      33.3      0.02     33.3
#> 2 match.arg                     0.02      33.3      0.02     33.3
#> 3 do.call                       0.01      16.7      0.01     16.7
#> 4 getOption                     0.01      16.7      0.01     16.7
#> 5 defer                         0.06     100        0         0
#> 6 prof_tbl                      0.06     100        0         0
#> 7 withr                         0.06     100        0         0
#> 8 is_top_level_global_env       0.02      33.3      0         0
```

It would be hard to do better without implementing in C. But then I think I'd move `defer()` from withr to rlang. The withr implementation can remain pure R.