### PR TITLE
 Call par() with no.readonly=TRUE to avoid warning

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,9 @@
 
 * `local_()` now works even if withr isn't attached (#207).
 
+* `local_par()` and `with_par()` now work if you don't set any parameters
+  (#238).
+
 * `defer()` is now a thin wrapper around `base::on.exit()`. This is
   possible thanks to two contributions that we made to R 3.5:
 

--- a/R/par.R
+++ b/R/par.R
@@ -5,7 +5,7 @@ NULL
 
 get_par <- function(...) {
   new <- auto_splice(list(...))
-  out <- do.call(graphics::par, as.list(names(new)))
+  out <- do.call(graphics::par, c(as.list(names(new)), list(no.readonly=TRUE)))
 
   # `par()` doesn't wrap in a list if input is length 1
   if (length(new) == 1) {

--- a/R/par.R
+++ b/R/par.R
@@ -5,7 +5,12 @@ NULL
 
 get_par <- function(...) {
   new <- auto_splice(list(...))
-  out <- do.call(graphics::par, c(as.list(names(new)), list(no.readonly=TRUE)))
+  if (length(new) == 0) {
+    # Only retrieve settable values
+    out <- graphics::par(no.readonly = TRUE)
+  } else {
+    out <- do.call(graphics::par, as.list(names(new)))
+  }
 
   # `par()` doesn't wrap in a list if input is length 1
   if (length(new) == 1) {

--- a/tests/testthat/test-local.R
+++ b/tests/testthat/test-local.R
@@ -184,6 +184,21 @@ test_that("local_par works as expected", {
   dev.off()
 })
 
+test_that("local_par gives no warning", {
+  tmp <- tempfile()
+
+  pdf(tmp)
+  on.exit(unlink(tmp), add = TRUE)
+
+  old <- par("pty")
+  expect_no_warning(local({
+    local_par()
+    par(pty="s")
+  }))
+  expect_equal(par("pty"), old)
+  dev.off()
+})
+
 test_that("supplying a getter to `local_()` shields against early exits", {
   my_get <- function(x) {
     out <- as.list(state)[names(x)]

--- a/tests/testthat/test-local.R
+++ b/tests/testthat/test-local.R
@@ -169,36 +169,6 @@ test_that("local_dir works as expected", {
   expect_equal(normalizePath(getwd()), normalizePath(old))
 })
 
-test_that("local_par works as expected", {
-  tmp <- tempfile()
-
-  pdf(tmp)
-  on.exit(unlink(tmp), add = TRUE)
-
-  old <- par("pty")
-  local({
-    local_par(list(pty = "s"))
-    expect_equal(par("pty"), "s")
-  })
-  expect_equal(par("pty"), old)
-  dev.off()
-})
-
-test_that("local_par gives no warning", {
-  tmp <- tempfile()
-
-  pdf(tmp)
-  on.exit(unlink(tmp), add = TRUE)
-
-  old <- par("pty")
-  expect_no_warning(local({
-    local_par()
-    par(pty="s")
-  }))
-  expect_equal(par("pty"), old)
-  dev.off()
-})
-
 test_that("supplying a getter to `local_()` shields against early exits", {
   my_get <- function(x) {
     out <- as.list(state)[names(x)]

--- a/tests/testthat/test-par.R
+++ b/tests/testthat/test-par.R
@@ -1,0 +1,27 @@
+test_that("with_par works as expected", {
+  local_pdf(local_tempfile())
+
+  old <- par("pty")
+  with_par(list(pty = "s"), {
+    expect_equal(par("pty"), "s")
+  })
+  expect_equal(par("pty"), old)
+  dev.off()
+})
+
+test_that("local_par works as expected", {
+  local_pdf(local_tempfile())
+
+  old <- par("pty")
+  local({
+    local_par(list(pty = "s"))
+    expect_equal(par("pty"), "s")
+  })
+  expect_equal(par("pty"), old)
+})
+
+test_that("empty par doesn't give warning", {
+  local_pdf(local_tempfile())
+
+  expect_no_warning(with_par(list(), par(pty="s")))
+})

--- a/tests/testthat/test-with.R
+++ b/tests/testthat/test-with.R
@@ -161,20 +161,6 @@ test_that("with_dir works as expected", {
   expect_equal(normalizePath(getwd()), normalizePath(old))
 })
 
-test_that("with_par works as expected", {
-  tmp <- tempfile()
-
-  pdf(tmp)
-  on.exit(unlink(tmp), add = TRUE)
-
-  old <- par("pty")
-  with_par(list(pty = "s"), {
-    expect_equal(par("pty"), "s")
-  })
-  expect_equal(par("pty"), old)
-  dev.off()
-})
-
 test_that("supplying a getter to `with_()` shields against early exits", {
   my_get <- function(x) {
     out <- as.list(state)[names(x)]


### PR DESCRIPTION
Fixes #237 