### PR TITLE
Throw error when `deferred_run()` is run in knitted document

### DIFF
--- a/R/defer.R
+++ b/R/defer.R
@@ -81,6 +81,9 @@ defer_parent <- function(expr, priority = c("first", "last")) {
 #' @rdname defer
 #' @export
 deferred_run <- function(envir = parent.frame()) {
+  if (knitr_in_progress()) {
+    stop("Can't run `deferred_run()` in a knitted document")
+  }
   if (is_top_level_global_env(envir)) {
     handlers <- the$global_exits
   } else {

--- a/tests/testthat/test-defer.R
+++ b/tests/testthat/test-defer.R
@@ -28,3 +28,18 @@ test_that("deferred_run() displays how many expressions were run", {
     deferred_run()
   })))
 })
+
+test_that("can't run `deferred_run()` in knitr", {
+    skip_if_cannot_knit()
+
+    rmd <- local_tempfile(fileext = ".Rmd")
+    writeLines(rmd, text = "
+```{r}
+withr::deferred_run()
+```
+")
+    expect_error(
+      suppressMessages(rmarkdown::render(rmd, quiet = TRUE)),
+      "in a knitted document"
+    )
+})


### PR DESCRIPTION
Stopgap until we can figure out #235.