### PR TITLE
Fix `deferred_run()` in knitr

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,8 @@
 * `deferred_run()` now reports the number of executed expressions with
   a message.
 
+* `deferred_run()` can now be run at any point in a knitr file (#235).
+
 ,* `local_tempfile()` now writes `lines` in UTF-8 (#210) and always uses 
   `\n` for newlines (#216).
 

--- a/R/defer.R
+++ b/R/defer.R
@@ -76,17 +76,18 @@ defer <- function(expr, envir = parent.frame(), priority = c("first", "last")) {
   }
 
   priority <- match.arg(priority, choices = c("first", "last"))
-  after <- priority == "last"
 
-  thunk <- as.call(list(function() expr))
+  if (knitr_in_progress() && identical(envir, knitr::knit_global())) {
+    return(defer_knitr(expr, envir, priority = priority))
+  }
 
-  # Don't handle `source()` and `knit()` specially by default
-  # to avoid a performance hit
-  hook_source <- getOption("withr.hook_source")
-  hook_knitr <- getOption("knitr.in.progress")
-  if (!is.null(hook_source) || !is.null(hook_knitr)) {
+  # Don't handle `source()` by default to avoid a performance hit
+  if (!is.null(getOption("withr.hook_source"))) {
     envir <- exit_frame(envir)
   }
+
+  thunk <- as.call(list(function() expr))
+  after <- priority == "last"
 
   do.call(
     base::on.exit,
@@ -217,6 +218,50 @@ is_top_level_global_env <- function(envir, frames = sys.frames()) {
 
   # Check if another global environment is on the stack
   !any(vapply(frames, identical, NA, globalenv()))
+}
+
+
+# This picks up knitr's first frame on the stack and registers the
+# handler there. To avoid mixing up knitr's own exit handlers with
+# ours, we don't hook directly but instead save the list of handlers
+# as an attribute on the frame environment.
+defer_knitr <- function(expr, envir, priority = c("first", "last")) {
+  priority <- match.arg(priority, choices = c("first", "last"))
+
+  envir <- exit_frame(envir)
+  handler <- as.call(list(function() expr))
+
+  handlers <- knitr_handlers(envir)
+
+  # Add `on.exit` hook if run for first time
+  if (!length(handlers)) {
+    defer_knitr_run(envir)
+  }
+
+  if (priority == "first") {
+    handlers <- c(list(handler), handlers)
+  } else {
+    handlers <- c(handlers, list(handler))
+  }
+  attr(envir, "withr_knitr_handlers") <- handlers
+
+  invisible(NULL)
+}
+
+knitr_handlers <- function(envir) {
+  attr(envir, "withr_knitr_handlers") %||% list()
+}
+
+# Evaluate `handlers` lazily so we get the latest version
+defer_knitr_run <- function(
+  envir,
+  handlers = knitr_handlers(envir)
+) {
+  defer(envir = envir, {
+    for (expr in handlers) {
+      eval(expr, envir)
+    }
+  })
 }
 
 

--- a/R/defer.R
+++ b/R/defer.R
@@ -83,7 +83,7 @@ defer <- function(expr, envir = parent.frame(), priority = c("first", "last")) {
 
   # Don't handle `source()` by default to avoid a performance hit
   if (!is.null(getOption("withr.hook_source"))) {
-    envir <- exit_frame(envir)
+    envir <- source_exit_frame(envir)
   }
 
   thunk <- as.call(list(function() expr))
@@ -228,7 +228,7 @@ is_top_level_global_env <- function(envir, frames = sys.frames()) {
 defer_knitr <- function(expr, envir, priority = c("first", "last")) {
   priority <- match.arg(priority, choices = c("first", "last"))
 
-  envir <- exit_frame(envir)
+  envir <- knitr_exit_frame(envir)
   handler <- as.call(list(function() expr))
 
   handlers <- knitr_handlers(envir)

--- a/R/defer.R
+++ b/R/defer.R
@@ -109,15 +109,19 @@ defer_parent <- function(expr, priority = c("first", "last")) {
 #' @rdname defer
 #' @export
 deferred_run <- function(envir = parent.frame()) {
-  if (knitr_in_progress()) {
-    stop("Can't run `deferred_run()` in a knitted document")
-  }
-  if (is_top_level_global_env(envir)) {
-    handlers <- the$global_exits
+  if (knitr_in_progress() && identical(envir, knitr::knit_global())) {
+    # The handlers are thunks so we don't need to clear them.
+    # They will only be run once.
+    frame <- knitr_exit_frame(envir)
+    handlers <- knitr_handlers(frame)
   } else {
-    handlers <- frame_exits(envir)
+    if (is_top_level_global_env(envir)) {
+      handlers <- the$global_exits
+    } else {
+      handlers <- frame_exits(envir)
+    }
+    deferred_clear(envir)
   }
-  deferred_clear(envir)
 
   n <- length(handlers)
   i <- 0L
@@ -224,7 +228,8 @@ is_top_level_global_env <- function(envir, frames = sys.frames()) {
 # This picks up knitr's first frame on the stack and registers the
 # handler there. To avoid mixing up knitr's own exit handlers with
 # ours, we don't hook directly but instead save the list of handlers
-# as an attribute on the frame environment.
+# as an attribute on the frame environment. This allows `deferred_run()`
+# to run our handlers without running the knitr ones.
 defer_knitr <- function(expr, envir, priority = c("first", "last")) {
   priority <- match.arg(priority, choices = c("first", "last"))
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -93,3 +93,7 @@ is_interactive <- function() {
   }
   interactive()
 }
+
+`%||%` <- function(x, y) {
+  if (is.null(x)) y else x
+}

--- a/tests/testthat/_snaps/defer.md
+++ b/tests/testthat/_snaps/defer.md
@@ -28,3 +28,53 @@
     Message
       Ran 1/3 deferred expressions
 
+# can't run `deferred_run()` in knitr
+
+    Code
+      writeLines(readLines(out))
+    Output
+      
+      
+      ```r
+      withr::deferred_run()
+      ```
+      
+      ```
+      ## No deferred expressions to run
+      ```
+      
+      ```r
+      defer(writeLines('1'))
+      writeLines('2')
+      ```
+      
+      ```
+      ## 2
+      ```
+      
+      ```r
+      defer(writeLines('3'))
+      ```
+      
+      ```r
+      writeLines('4')
+      ```
+      
+      ```
+      ## 4
+      ```
+      
+      ```r
+      withr::deferred_run()
+      ```
+      
+      ```
+      ## 3
+      ## 1
+      ```
+      
+      ```
+      ## Ran 2/2 deferred expressions
+      ```
+      
+

--- a/tests/testthat/test-defer.R
+++ b/tests/testthat/test-defer.R
@@ -33,13 +33,25 @@ test_that("can't run `deferred_run()` in knitr", {
     skip_if_cannot_knit()
 
     rmd <- local_tempfile(fileext = ".Rmd")
+    out <- local_tempfile(fileext = ".md")
     writeLines(rmd, text = "
 ```{r}
 withr::deferred_run()
 ```
+```{r}
+defer(writeLines('1'))
+writeLines('2')
+defer(writeLines('3'))
+```
+```{r}
+writeLines('4')
+withr::deferred_run()
+```
 ")
-    expect_error(
-      suppressMessages(rmarkdown::render(rmd, quiet = TRUE)),
-      "in a knitted document"
-    )
+
+    knitr::knit(rmd, out, quiet = TRUE)
+
+    expect_snapshot({
+      writeLines(readLines(out))
+    })
 })

--- a/vignettes/changing-and-restoring-state.Rmd
+++ b/vignettes/changing-and-restoring-state.Rmd
@@ -311,28 +311,21 @@ It's hard to develop with functions that work one way inside a function, but ano
 
 Here's how `defer()` (and all functions based on it) works in an interactive session.
 
-```{r eval = FALSE}
+```{r}
 library(withr)
 
 defer(print("hi"))
-#> Setting deferred event(s) on global environment.
-#>   * Execute (and clear) with `withr::deferred_run()`.
-#>   * Clear (without executing) with `withr::deferred_clear()`.
 
 pi
-#> [1] 3.141593
 
 # this adds another deferred event, but does not re-message
 local_digits(3)
 
 pi
-#> [1] 3.14
 
 deferred_run()
-#> [1] "hi"
 
 pi
-#> [1] 3.141593
 ```
 
 When you defer events on the global environment, you get a message that alerts you to the situation.


### PR DESCRIPTION
Branched from #250.
Closes #235.

Throwing an error causes a testthat vignette to fail (see https://github.com/r-lib/testthat/pull/1920). And now that we no longer use `exit_frame()` as the public interface for handling environments specially, it's easier to introduce special-casing for knitr. We now use the old approach of attaching a list of handlers to the knitr exit frame. This way our handlers are not mixed with knitr's own handlers and we can flush them separately.

Fixes the testthat failure in revdeps.