### PR TITLE
Allow pkgload to hotpatch `::`

### DIFF
--- a/R/with.R
+++ b/R/with.R
@@ -59,3 +59,6 @@
 #' }
 #' Sys.getenv("WITHR")
 "_PACKAGE"
+
+# Enable pkgload to hotpatch `::` in detached namespaces
+on_load(`::` <- base::`::`)


### PR DESCRIPTION
Supersedes and closes https://github.com/r-lib/pkgload/pull/291