### PR TITLE
Never warn if `LANGUAGE` is set to `"C"`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # withr (development version)
 
+* `local_language()` now never warns when set to `"C"` (#254).
+  This is a cross-platform and silent way of disabling `gettext()`
+  translations.
+
+
 # withr 3.0.1
 
 * Fixes for CRAN checks.
@@ -41,10 +46,10 @@
 
 * `deferred_run()` can now be run at any point in a knitr file (#235).
 
-* `local_tempfile()` now writes `lines` in UTF-8 (#210) and always uses 
+* `local_tempfile()` now writes `lines` in UTF-8 (#210) and always uses
   `\n` for newlines (#216).
 
-* `local_pdf()` and friends now correctly restore to the previously 
+* `local_pdf()` and friends now correctly restore to the previously
   active device (#138).
 
 * `local_()` now works even if withr isn't attached (#207).
@@ -132,7 +137,7 @@
 
 * Lionel Henry is the new maintainer.
 
-* Handlers registered with the global environment (as happens when `local_()` 
+* Handlers registered with the global environment (as happens when `local_()`
   is run at the top-level, outside a function) are now automatically run
   when the R session ends (#173).
 

--- a/R/language.R
+++ b/R/language.R
@@ -34,23 +34,26 @@ local_language <- function(lang, .local_envir = parent.frame()) {
   # https://stackoverflow.com/questions/6152321
   lang <- gsub("-", "_", lang, fixed = TRUE)
 
-  if (!has_nls()) {
-    warning("Changing language has no effect when R installed without NLS")
-  }
+  # Only warn if setting `LANGUAGE` to something other than `"C"` (#254)
+  if (lang != "C") {
+    if (!has_nls()) {
+      warning("Changing language has no effect when R installed without NLS")
+    }
 
-  # > Note: The variable LANGUAGE is ignored if the locale is set to ‘C’.
-  # > In other words, you have to first enable localization, by setting LANG
-  # > (or LC_ALL) to a value other than ‘C’, before you can use a language
-  # > priority list through the LANGUAGE variable.
-  # --- https://www.gnu.org/software/gettext/manual/html_node/The-LANGUAGE-variable.html
+    # > Note: The variable LANGUAGE is ignored if the locale is set to ‘C’.
+    # > In other words, you have to first enable localization, by setting LANG
+    # > (or LC_ALL) to a value other than ‘C’, before you can use a language
+    # > priority list through the LANGUAGE variable.
+    # --- https://www.gnu.org/software/gettext/manual/html_node/The-LANGUAGE-variable.html
 
-  # `LC_ALL` has precedence over `LANG`. Check for the latter if the
-  # former is unset, otherwise check for the former.
-  if (Sys.getenv("LC_ALL", "") == "") {
-    # Causes too many failures because testthat sets `LANG` to "C"
-    # check_language_envvar("LANG")
-  } else {
-    check_language_envvar("LC_ALL")
+    # `LC_ALL` has precedence over `LANG`. Check for the latter if the
+    # former is unset, otherwise check for the former.
+    if (Sys.getenv("LC_ALL", "") == "") {
+      # Causes too many failures because testthat sets `LANG` to "C"
+      # check_language_envvar("LANG")
+    } else {
+      check_language_envvar("LC_ALL")
+    }
   }
 
   local_envvar(LANGUAGE = lang, .local_envir = .local_envir)


### PR DESCRIPTION
Part of #254 and r-lib/testthat#1925.

We're going to use `local_language("C")` as a simple way of reliably disabling translations across platforms.

I'll do a quick patch release so that testthat can depend on this change.