### PR TITLE
Use get0 to simplify get_seed()

### DIFF
--- a/R/seed.R
+++ b/R/seed.R
@@ -96,11 +96,8 @@ has_seed <- function() {
 }
 
 get_seed <- function() {
-  if (!has_seed()) {
-    return(NULL)
-  }
   list(
-    random_seed = get(".Random.seed", globalenv(), mode = "integer", inherits = FALSE),
+    random_seed = get0(".Random.seed", globalenv(), mode = "integer", inherits = FALSE),
     rng_kind = RNGkind()
   )
 }


### PR DESCRIPTION
This looks like a good place to use `get0()` (with its default of `ifnotfound=NULL`, which we could also make explicit here for clarity).

Feel free to reject if you prefer the current implementation.