### PR TITLE
Don't call `on.exit()` inside `defer()` calls in `local_seed()`

### DIFF
--- a/R/seed.R
+++ b/R/seed.R
@@ -44,9 +44,9 @@ local_seed <- function(seed,
 
   defer(envir = .local_envir, {
     if (is.null(old_seed)) {
-      on.exit(rm_seed(), add = TRUE)
+      rm_seed()
     } else {
-      on.exit(set_seed(old_seed), add = TRUE)
+      set_seed(old_seed)
     }
   })
 

--- a/tests/testthat/test-seed.R
+++ b/tests/testthat/test-seed.R
@@ -69,6 +69,17 @@ test_that("local_seed works as expected", {
   expect_false(x == y)
 })
 
+test_that("local_seed doesn't modify `.Random.seed` (#286)", {
+  f1 <- function(n, seed) {
+    local_seed(seed)
+    rnorm(n)
+  }
+  set.seed(42)
+  seed3 <- .Random.seed
+  rslt3 <- f1(5, 41)
+  expect_identical(seed3, .Random.seed)
+})
+
 test_that("with_preserve_seed preserves empty seed", {
   rm_seed()
   with_preserve_seed(runif(1))


### PR DESCRIPTION
This removes the `on.exit()` calls inside `defer()` in `local_seed()`, which made the `.Random.seed` not be restored correctly.

Fixes #286