### PR TITLE
docs: add examples for local_tempdir() and with_tempdir()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -39,7 +39,6 @@ Config/Needs/website: tidyverse/tidytemplate
 Config/testthat/edition: 3
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.2
 Collate:
     'aaa.R'
     'collate.R'
@@ -71,3 +70,4 @@ Collate:
     'torture.R'
     'utils.R'
     'with.R'
+Config/roxygen2/version: 8.0.0

--- a/R/tempfile.R
+++ b/R/tempfile.R
@@ -29,6 +29,27 @@
 #'
 #' # Note that this variable is only available in the scope of with_tempfile
 #' try(path2)
+#'
+#' # local_tempdir() creates a temporary directory and returns its path
+#' local({
+#'   dir_path <- local_tempdir()
+#'   dir.exists(dir_path)
+#'   # create a file inside it
+#'   writeLines("hello", file.path(dir_path, "test.txt"))
+#'   file.exists(file.path(dir_path, "test.txt"))
+#' })
+#' # the directory and its contents are deleted automatically
+#' file.exists(dir_path)
+#'
+#' # with_tempdir() temporarily changes the working directory to a temp dir
+#' getwd()
+#' with_tempdir({
+#'   getwd()
+#'   writeLines("test", "example.txt")
+#'   list.files()
+#' })
+#' # the original working directory is restored
+#' getwd()
 #' @export
 with_tempfile <- function(new, code, envir = parent.frame(), .local_envir = parent.frame(),
   pattern = "file", tmpdir = tempdir(), fileext = "") {

--- a/man/with_tempfile.Rd
+++ b/man/with_tempfile.Rd
@@ -93,6 +93,27 @@ with_tempfile("path2", {
 
 # Note that this variable is only available in the scope of with_tempfile
 try(path2)
+
+# local_tempdir() creates a temporary directory and returns its path
+local({
+  dir_path <- local_tempdir()
+  dir.exists(dir_path)
+  # create a file inside it
+  writeLines("hello", file.path(dir_path, "test.txt"))
+  file.exists(file.path(dir_path, "test.txt"))
+})
+# the directory and its contents are deleted automatically
+file.exists(dir_path)
+
+# with_tempdir() temporarily changes the working directory to a temp dir
+getwd()
+with_tempdir({
+  getwd()
+  writeLines("test", "example.txt")
+  list.files()
+})
+# the original working directory is restored
+getwd()
 }
 \seealso{
 \code{\link{withr}} for examples


### PR DESCRIPTION
Closes #283

Adds runnable examples for `local_tempdir()` and `with_tempdir()` to the shared `with_tempfile` help page. Previously only `local_tempfile()` and `with_tempfile()` had examples.

Examples demonstrate:
- `local_tempdir()`: returns a path, auto-deletes on scope exit
- `with_tempdir()`: temporarily changes working directory, restores after

Validation:
- `tools::checkRd()` passes
- Examples run successfully
- R CMD check: pre-existing errors in `with_locale` and `test-language.R` (unrelated)